### PR TITLE
Fixed signal names in InAppPurchase Godot sample project and upgraded to Godot 4.4.

### DIFF
--- a/InAppPurchase/Godot/addons/iosplugins/inapppurchase.gdextension.uid
+++ b/InAppPurchase/Godot/addons/iosplugins/inapppurchase.gdextension.uid
@@ -1,0 +1,1 @@
+uid://cibkdwq54jghg

--- a/InAppPurchase/Godot/main.gd
+++ b/InAppPurchase/Godot/main.gd
@@ -10,18 +10,18 @@ func _ready() -> void:
 	if _inapppurchase == null && ClassDB.class_exists("InAppPurchase"):
 		_inapppurchase = ClassDB.instantiate("InAppPurchase")
 		_inapppurchase.in_app_purchase_fetch_success.connect(_on_in_app_purchase_fetch_success)
-		_inapppurchase.in_app_purchase_fetch_fail.connect(_on_in_app_purchase_fetch_fail)
+		_inapppurchase.in_app_purchase_fetch_error.connect(_on_in_app_purchase_fetch_error)
 		_inapppurchase.in_app_purchase_success.connect(_on_in_app_purchase_success)
-		_inapppurchase.in_app_purchase_fail.connect(_on_in_app_purchase_fail)
+		_inapppurchase.in_app_purchase_error.connect(_on_in_app_purchase_error)
 		_inapppurchase.in_app_purchase_restore_success.connect(_on_in_app_purchase_restore_success)
-		_inapppurchase.in_app_purchase_restore_fail.connect(_on_in_app_purchase_restore_fail)
+		_inapppurchase.in_app_purchase_restore_error.connect(_on_in_app_purchase_restore_error)
 
 		status_label.text = "Plugin loaded"
 	else:
 		status_label.text = "No plugin"
 
 
-func _on_in_app_purchase_fetch_fail(error: int, message: String) -> void:
+func _on_in_app_purchase_fetch_error(error: int, message: String) -> void:
 	status_label.text = message
 
 
@@ -40,7 +40,7 @@ func _on_in_app_purchase_success(message: String) -> void:
 	status_label.text = "Product %s purchased" % message
 
 
-func _on_in_app_purchase_fail(error: int, message: String) -> void:
+func _on_in_app_purchase_error(error: int, message: String) -> void:
 	status_label.text = message
 
 
@@ -49,7 +49,7 @@ func _on_in_app_purchase_restore_success(products: Array[Variant]) -> void:
 		status_label.text = str(product)
 
 
-func _on_in_app_purchase_restore_fail(error: int, message: String) -> void:
+func _on_in_app_purchase_restore_error(error: int, message: String) -> void:
 	status_label.text = message
 
 

--- a/InAppPurchase/Godot/main.gd.uid
+++ b/InAppPurchase/Godot/main.gd.uid
@@ -1,0 +1,1 @@
+uid://w2fxq6pe5y2q

--- a/InAppPurchase/Godot/main.tscn
+++ b/InAppPurchase/Godot/main.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://byl7mgh8ljwlt"]
 
-[ext_resource type="Script" path="res://main.gd" id="1_fli7h"]
+[ext_resource type="Script" uid="uid://w2fxq6pe5y2q" path="res://main.gd" id="1_fli7h"]
 
 [node name="Main" type="Control"]
 layout_mode = 3

--- a/InAppPurchase/Godot/project.godot
+++ b/InAppPurchase/Godot/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="InAppPurchases"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.3", "Mobile")
+config/features=PackedStringArray("4.4", "Mobile")
 config/icon="res://icon.svg"
 
 [display]

--- a/InAppPurchase/README.md
+++ b/InAppPurchase/README.md
@@ -17,33 +17,33 @@ func _ready() -> void:
 	if _inapppurchase == null && ClassDB.class_exists("InAppPurchase"):
 		_inapppurchase = ClassDB.instantiate("InAppPurchase")
 		_inapppurchase.in_app_purchase_fetch_success.connect(_on_in_app_purchase_fetch_success)
-		_inapppurchase.in_app_purchase_fetch_fail.connect(_on_in_app_purchase_fetch_fail)
+		_inapppurchase.in_app_purchase_fetch_error.connect(_on_in_app_purchase_fetch_error)
 		_inapppurchase.in_app_purchase_success.connect(_on_in_app_purchase_success)
-		_inapppurchase.in_app_purchase_fail.connect(_on_in_app_purchase_fail)
+		_inapppurchase.in_app_purchase_error.connect(_on_in_app_purchase_error)
 		_inapppurchase.in_app_purchase_restore_success.connect(_on_in_app_purchase_restore_success)
-		_inapppurchase.in_app_purchase_restore_fail.connect(_on_in_app_purchase_restore_fail)
+		_inapppurchase.in_app_purchase_restore_error.connect(_on_in_app_purchase_restore_error)
 ```
 
 The Godot method signature required
 
 ```
-func _on_in_app_purchase_fetch_fail(error: int, message: String) -> void:
+func _on_in_app_purchase_fetch_error(error: int, message: String) -> void:
 func _on_in_app_purchase_fetch_success(products: Array[InAppPurchaseProduct]) -> void:
 func _on_in_app_purchase_success(message: String) -> void:
-func _on_in_app_purchase_fail(error: int, message: String) -> void:
+func _on_in_app_purchase_error(error: int, message: String) -> void:
 func _on_in_app_purchase_restore_success(products: Array[Variant]) -> void:
-func _on_in_app_purchase_restore_fail(error: int, message: String) -> void:
+func _on_in_app_purchase_restore_error(error: int, message: String) -> void:
 ```
 
 # Technical details
 
 ## Signals
 - `in_app_purchase_fetch_success` SignalWithArguments<ObjectCollection<InAppPurchaseProduct>>
-- `in_app_purchase_fetch_fail` SignalWithArguments<Int,Dictionary>
+- `in_app_purchase_fetch_error` SignalWithArguments<Int,Dictionary>
 - `in_app_purchase_success` SignalWithArguments<String>
-- `in_app_purchase_fail` SignalWithArguments<Int,Dictionary>
+- `in_app_purchase_error` SignalWithArguments<Int,Dictionary>
 - `in_app_purchase_restore_success` SignalWithArguments<GArray>
-- `in_app_purchase_restore_fail` SignalWithArguments<Int,Dictionary>
+- `in_app_purchase_restore_error` SignalWithArguments<Int,Dictionary>
 
 ## Methods
 

--- a/InAppPurchase/Swift/Sources/InAppPurchase/InAppPurchase.swift
+++ b/InAppPurchase/Swift/Sources/InAppPurchase/InAppPurchase.swift
@@ -25,6 +25,7 @@ enum InAppPurchaseError: Int, Error {
     case failedToPurchase = 6
     case failedToVerify = 7
     case failedToRestore = 8
+    case pending = 9
 
     var localizedDescription: String {
         switch self {
@@ -44,6 +45,8 @@ enum InAppPurchaseError: Int, Error {
             return "Failed to verify purchase."
         case .failedToRestore:
             return "Failed to restore purchases."
+        case .pending:
+            return "The purchase is pending some user action."
         }
     }
 }


### PR DESCRIPTION
- Upgraded to Godot 4.4.
- InAppPurchase fixes:
  - Fixed _error signals in Godot sample project. They were set up as _fail, which doesn't match the plugin.
  - Updated README.md to show correct signal name changes.
  - Added missing InAppPurchaseError enum case in plugin Swift code, as it was preventing compilation.