### PR TITLE
Added auto-renewable subscription transaction counts to InAppPurchase.

### DIFF
--- a/InAppPurchase/Godot/main.gd
+++ b/InAppPurchase/Godot/main.gd
@@ -13,6 +13,7 @@ func _ready() -> void:
 		_inapppurchase.in_app_purchase_fetch_success.connect(_on_in_app_purchase_fetch_success)
 		_inapppurchase.in_app_purchase_fetch_error.connect(_on_in_app_purchase_fetch_error)
 		_inapppurchase.in_app_purchase_fetch_active_auto_renewable_subscriptions.connect(_on_in_app_purchase_fetch_active_auto_renewable_subscriptions)
+		_inapppurchase.in_app_purchase_fetch_auto_renewable_transaction_counts.connect(_on_in_app_purchase_fetch_auto_renewable_transaction_counts)
 		_inapppurchase.in_app_purchase_success.connect(_on_in_app_purchase_success)
 		_inapppurchase.in_app_purchase_error.connect(_on_in_app_purchase_error)
 		_inapppurchase.in_app_purchase_restore_success.connect(_on_in_app_purchase_restore_success)
@@ -38,6 +39,7 @@ func _on_in_app_purchase_fetch_success(products: Array[InAppPurchaseProduct]) ->
 	$MarginContainer/VBoxContainer/PurchaseSubscriptionButton.disabled = false
 	$MarginContainer/VBoxContainer/PurchaseSubscriptionNorenewButton.disabled = false
 	$MarginContainer/VBoxContainer/FetchActiveAutoRenewableSubscriptionsButton.disabled = false
+	$MarginContainer/VBoxContainer/FetchAutoRenewableTransactionCountsButton.disabled = false
 
 
 func _on_in_app_purchase_fetch_active_auto_renewable_subscriptions(product_ids: Array[Variant]) -> void:
@@ -46,6 +48,14 @@ func _on_in_app_purchase_fetch_active_auto_renewable_subscriptions(product_ids: 
 		print("%s" % product_id)
 		_active_auto_renewable_subscription_product_ids.append(product_id)
 	status_label.text = "Active subscriptions received: %d" % len(_active_auto_renewable_subscription_product_ids)
+
+
+func _on_in_app_purchase_fetch_auto_renewable_transaction_counts(counts: Dictionary) -> void:
+	print("counts: %s" % counts)
+	if counts:
+		status_label.text = "counts: %s" % counts
+	else:
+		status_label.text = "no transactions"
 
 
 func _on_in_app_purchase_success(message: String) -> void:
@@ -90,6 +100,10 @@ func _on_purchase_subscription_norenew_button_pressed() -> void:
 
 func _on_fetch_active_auto_renewable_subscriptions_button_pressed() -> void:
 	_inapppurchase.fetchActiveAutoRenewableSubscriptions()
+
+
+func _on_fetch_auto_renewable_transaction_counts_button_pressed() -> void:
+	_inapppurchase.fetchAutoRenewableTransactionCounts()
 
 
 func _on_restore_button_pressed() -> void:

--- a/InAppPurchase/Godot/main.tscn
+++ b/InAppPurchase/Godot/main.tscn
@@ -30,24 +30,24 @@ theme_override_constants/separation = 20
 alignment = 1
 
 [node name="LoadProductsButton" type="Button" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 130)
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 text = "Load products"
 
 [node name="PurchaseConsumableButton" type="Button" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 130)
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 disabled = true
 text = "Purchase consumable"
 
 [node name="PurchaseNonConsumableButton" type="Button" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 130)
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 disabled = true
 text = "Purchase non consumable"
 
 [node name="PurchaseSubscriptionButton" type="Button" parent="MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 130)
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 disabled = true
 text = "Purchase subscription"
@@ -66,8 +66,15 @@ disabled = true
 text = "Fetch active subscriptions
 auto-renewable"
 
-[node name="RestoreButton" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="FetchAutoRenewableTransactionCountsButton" type="Button" parent="MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(0, 130)
+layout_mode = 2
+disabled = true
+text = "Fetch transaction counts
+auto-renewable"
+
+[node name="RestoreButton" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 text = "Restore purchases"
 
@@ -81,4 +88,5 @@ horizontal_alignment = 1
 [connection signal="pressed" from="MarginContainer/VBoxContainer/PurchaseSubscriptionButton" to="." method="_on_purchase_subscription_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/PurchaseSubscriptionNorenewButton" to="." method="_on_purchase_subscription_norenew_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/FetchActiveAutoRenewableSubscriptionsButton" to="." method="_on_fetch_active_auto_renewable_subscriptions_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/FetchAutoRenewableTransactionCountsButton" to="." method="_on_fetch_auto_renewable_transaction_counts_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/RestoreButton" to="." method="_on_restore_button_pressed"]

--- a/InAppPurchase/README.md
+++ b/InAppPurchase/README.md
@@ -19,6 +19,7 @@ func _ready() -> void:
 		_inapppurchase.in_app_purchase_fetch_success.connect(_on_in_app_purchase_fetch_success)
 		_inapppurchase.in_app_purchase_fetch_error.connect(_on_in_app_purchase_fetch_error)
 		_inapppurchase.in_app_purchase_fetch_active_auto_renewable_subscriptions.connect(_on_in_app_purchase_fetch_active_auto_renewable_subscriptions)
+		_inapppurchase.in_app_purchase_fetch_auto_renewable_transaction_counts.connect(_on_in_app_purchase_fetch_auto_renewable_transaction_counts)
 		_inapppurchase.in_app_purchase_success.connect(_on_in_app_purchase_success)
 		_inapppurchase.in_app_purchase_error.connect(_on_in_app_purchase_error)
 		_inapppurchase.in_app_purchase_restore_success.connect(_on_in_app_purchase_restore_success)
@@ -31,6 +32,7 @@ The Godot method signature required
 func _on_in_app_purchase_fetch_error(error: int, message: String) -> void:
 func _on_in_app_purchase_fetch_success(products: Array[InAppPurchaseProduct]) -> void:
 func _on_in_app_purchase_fetch_active_auto_renewable_subscriptions(product_ids: Array[Variant]) -> void:
+func _on_in_app_purchase_fetch_auto_renewable_transaction_counts(counts: Dictionary) -> void:
 func _on_in_app_purchase_success(message: String) -> void:
 func _on_in_app_purchase_error(error: int, message: String) -> void:
 func _on_in_app_purchase_restore_success(product_ids: Array[Variant]) -> void:
@@ -43,6 +45,7 @@ func _on_in_app_purchase_restore_error(error: int, message: String) -> void:
 - `in_app_purchase_fetch_success` SignalWithArguments<ObjectCollection<InAppPurchaseProduct>>
 - `in_app_purchase_fetch_error` SignalWithArguments<Int,Dictionary>
 - `in_app_purchase_fetch_active_auto_renewable_subscriptions` SignalWithArguments<GArray>
+- `in_app_purchase_fetch_auto_renewable_transaction_counts` SignalWithArguments<GDictionary>
 - `in_app_purchase_success` SignalWithArguments<String>
 - `in_app_purchase_error` SignalWithArguments<Int,Dictionary>
 - `in_app_purchase_restore_success` SignalWithArguments<GArray>
@@ -52,5 +55,6 @@ func _on_in_app_purchase_restore_error(error: int, message: String) -> void:
 
 - `fetchProducts(products: [String])` - Fetch all products given in input, this method **must** be called once before any purchase.
 - `fetchActiveAutoRenewableSubscriptions()` - Fetch all active auto-renewable subscriptions, returning a list of product ids.
+- `fetchAutoRenewableTransactionCounts()` - Fetch all auto-renewable subscription transaction counts. Returns a dictionary, with product ids as the key, and the number of transactions is the value.  Useful for tracking monthly awards, etc.
 - `purchaseProduct(productID: String)` - Purchase a given pruduct.
 - `restorePurchases()` - Restore all the previous purchased products, returning a list of product ids.

--- a/InAppPurchase/README.md
+++ b/InAppPurchase/README.md
@@ -55,6 +55,6 @@ func _on_in_app_purchase_restore_error(error: int, message: String) -> void:
 
 - `fetchProducts(products: [String])` - Fetch all products given in input, this method **must** be called once before any purchase.
 - `fetchActiveAutoRenewableSubscriptions()` - Fetch all active auto-renewable subscriptions, returning a list of product ids.
-- `fetchAutoRenewableTransactionCounts()` - Fetch all auto-renewable subscription transaction counts. Returns a dictionary, with product ids as the key, and the number of transactions is the value.  Useful for tracking monthly awards, etc.
+- `fetchAutoRenewableTransactionCounts()` - Fetch all auto-renewable subscription transaction counts. Returns a dictionary, with product ids as the key, and the number of transactions as the value.  Useful for tracking monthly awards, etc.
 - `purchaseProduct(productID: String)` - Purchase a given pruduct.
 - `restorePurchases()` - Restore all the previous purchased products, returning a list of product ids.

--- a/InAppPurchase/Swift/Sources/InAppPurchase/InAppPurchase.swift
+++ b/InAppPurchase/Swift/Sources/InAppPurchase/InAppPurchase.swift
@@ -119,15 +119,19 @@ class InAppPurchase: Object , ObservableObject {
             with: products,
             completion: { error in
                 guard error == nil else {
-                    self.inAppPurchaseFetchError.emit(
-                        error!.rawValue, error!.localizedDescription)
+                    DispatchQueue.main.async {
+                        self.inAppPurchaseFetchError.emit(
+                            error!.rawValue, error!.localizedDescription)
+                    }
                     return
                 }
                 var iapProducts = ObjectCollection<InAppPurchaseProduct>()
                 for product in self.products_cached {
                     iapProducts.append(InAppPurchaseProduct(product: product))
                 }
-                self.inAppPurchaseFetchSuccess.emit(iapProducts)
+                DispatchQueue.main.async {
+                    self.inAppPurchaseFetchSuccess.emit(iapProducts)
+                }
             })
     }
 
@@ -139,7 +143,9 @@ class InAppPurchase: Object , ObservableObject {
         fetchActiveAutoRenewableSubscriptionsAsync(completion: { products in
             var productsArray = GArray()
             products.forEach { productsArray.append(Variant($0)) }
-            self.inAppPurchaseFetchActiveAutoRenewableSubscriptions.emit(productsArray)
+            DispatchQueue.main.async {
+                self.inAppPurchaseFetchActiveAutoRenewableSubscriptions.emit(productsArray)
+            }
         })
     }
 
@@ -161,7 +167,9 @@ class InAppPurchase: Object , ObservableObject {
             // Convert the dictionary to a GDictionary, and pass it back to Godot via the signal.
             var countGDictionary = GDictionary()
             autoRenewableTransactionCounts.forEach { countGDictionary[Variant($0.key)] = Variant($0.value) }
-            self.inAppPurchaseFetchAutoRenewableTransactionCounts.emit(countGDictionary)
+            DispatchQueue.main.async {
+                self.inAppPurchaseFetchAutoRenewableTransactionCounts.emit(countGDictionary)
+            }
         })
     }
 
@@ -174,11 +182,15 @@ class InAppPurchase: Object , ObservableObject {
             productID,
             completion: { error in
                 guard error == nil else {
-                    self.inAppPurchaseError.emit(
-                        error!.rawValue, error!.localizedDescription)
+                    DispatchQueue.main.async {
+                        self.inAppPurchaseError.emit(
+                            error!.rawValue, error!.localizedDescription)
+                    }
                     return
                 }
-                self.inAppPurchaseSuccess.emit(productID)
+                DispatchQueue.main.async {
+                    self.inAppPurchaseSuccess.emit(productID)
+                }
             })
     }
 
@@ -189,13 +201,17 @@ class InAppPurchase: Object , ObservableObject {
     func restorePurchases() {
         restorePurchasesAsync(completion: { products, error in
             guard error == nil else {
-                self.inAppPurchaseRestoreError.emit(
-                    error!.rawValue, error!.localizedDescription)
+                DispatchQueue.main.async {
+                    self.inAppPurchaseRestoreError.emit(
+                        error!.rawValue, error!.localizedDescription)
+                }
                 return
             }
             var productsArray = GArray()
             products.forEach { productsArray.append(Variant($0)) }
-            self.inAppPurchaseRestoreSuccess.emit(productsArray)
+            DispatchQueue.main.async {
+                self.inAppPurchaseRestoreSuccess.emit(productsArray)
+            }
         })
     }
 


### PR DESCRIPTION
InAppPurchase changes:
- Added callable fetchAutoRenewableTransactionCounts() function.
- Added in_app_purchase_fetch_auto_renewable_transaction_counts signal.
- Added button and functionality to Godot sample project to fetch the auto-renewable transaction counts.
- Updated readme file.
- Above changes will allow tracking rewards granted on each subscription renewal, like monthly rewards, etc., even if the player doesn't log into the game for a long period of time, or if their subscription is no longer active, but they are owed rewards from when they were subscribed previously.
- Moved all emits to the main thread, to prevent crashes with UI changes in a background thread.