### PR TITLE
Add leaderboard data retrieval methods

### DIFF
--- a/GameCenter/README.md
+++ b/GameCenter/README.md
@@ -11,30 +11,32 @@ More functionality may be added based on needs.
 # How to use it
 See Godot demo project for an end to end implementation.
 Register all the signals required, this can be done in the ``_ready()`` method and connect each signal to the relative method.
-
 ```
 func _ready() -> void:
-	if _gamecenter == null && ClassDB.class_exists("GameCenter"):
-		_gamecenter = ClassDB.instantiate("GameCenter")
-		_gamecenter.signin_success.connect(_on_signin_success)
-		_gamecenter.signin_fail.connect(_on_signin_fail)
-		_gamecenter.achievements_description_success.connect(_on_achievements_description_success)
-		_gamecenter.achievements_description_fail.connect(_on_achievements_description_fail)
-		_gamecenter.achievements_report_success.connect(_on_achievements_report_success)
-		_gamecenter.achievements_report_fail.connect(_on_achievements_report_fail)
-		_gamecenter.achievements_load_success.connect(_on_achievements_load_success)
-		_gamecenter.achievements_load_fail.connect(_on_achievements_load_fail)
-		_gamecenter.achievements_reset_success.connect(_on_achievements_reset_success)
-		_gamecenter.achievements_reset_fail.connect(_on_achievements_reset_fail)
-		_gamecenter.leaderboard_score_success.connect(_on_leaderboard_score_success)
-		_gamecenter.leaderboard_score_fail.connect(_on_leaderboard_score_fail)
-		_gamecenter.leaderboard_success.connect(_on_leaderboard_success)
-		_gamecenter.leaderboard_dismissed.connect(_on_leaderboard_dismissed)
-		_gamecenter.leaderboard_fail.connect(_on_leaderboard_fail)
+    if _gamecenter == null && ClassDB.class_exists("GameCenter"):
+        _gamecenter = ClassDB.instantiate("GameCenter")
+        _gamecenter.signin_success.connect(_on_signin_success)
+        _gamecenter.signin_fail.connect(_on_signin_fail)
+        _gamecenter.achievements_description_success.connect(_on_achievements_description_success)
+        _gamecenter.achievements_description_fail.connect(_on_achievements_description_fail)
+        _gamecenter.achievements_report_success.connect(_on_achievements_report_success)
+        _gamecenter.achievements_report_fail.connect(_on_achievements_report_fail)
+        _gamecenter.achievements_load_success.connect(_on_achievements_load_success)
+        _gamecenter.achievements_load_fail.connect(_on_achievements_load_fail)
+        _gamecenter.achievements_reset_success.connect(_on_achievements_reset_success)
+        _gamecenter.achievements_reset_fail.connect(_on_achievements_reset_fail)
+        _gamecenter.leaderboard_score_success.connect(_on_leaderboard_score_success)
+        _gamecenter.leaderboard_score_fail.connect(_on_leaderboard_score_fail)
+        _gamecenter.leaderboard_success.connect(_on_leaderboard_success)
+        _gamecenter.leaderboard_dismissed.connect(_on_leaderboard_dismissed)
+        _gamecenter.leaderboard_fail.connect(_on_leaderboard_fail)
+        _gamecenter.leaderboard_entries_load_success.connect(_on_leaderboard_entries_load_success)
+        _gamecenter.leaderboard_entries_load_fail.connect(_on_leaderboard_entries_load_fail)
+        _gamecenter.leaderboard_player_score_load_success.connect(_on_leaderboard_player_score_load_success)
+        _gamecenter.leaderboard_player_score_load_fail.connect(_on_leaderboard_player_score_load_fail)
 ```
 
 The Godot method signature required
-
 ```
 func _on_signin_fail(error: int, message: String) -> void:
 func _on_signin_success(player: GameCenterPlayerLocal) -> void:
@@ -46,10 +48,15 @@ func _on_achievements_load_fail(error: int, message: String) -> void:
 func _on_achievements_load_success(achievements: Array[GameCenterAchievement]) -> void:
 func _on_achievements_reset_fail(error: int, message: String) -> void:
 func _on_achievements_reset_success() -> void:
-func _on_leaderboard_score_success() -> void:
-func _on_leaderboard_score_fail(error: int, message: String) -> void:
+func _on_leaderboard_score_success(leaderboard_id: String) -> void:
+func _on_leaderboard_score_fail(error: int, message: String, leaderboard_id: String) -> void:
 func _on_leaderboard_dismissed() -> void:
 func _on_leaderboard_success() -> void:
+func _on_leaderboard_fail(error: int, message: String) -> void:
+func _on_leaderboard_entries_load_success(entries: Array[GameCenterLeaderboardEntry], total_player_count: int, leaderboard_id: String) -> void:
+func _on_leaderboard_entries_load_fail(error: int, message: String, leaderboard_id: String) -> void:
+func _on_leaderboard_player_score_load_success(entry: GameCenterLeaderboardEntry, leaderboard_id: String) -> void:
+func _on_leaderboard_player_score_load_fail(error: int, message: String, leaderboard_id: String) -> void:
 ```
 
 # Technical details
@@ -68,11 +75,24 @@ func _on_leaderboard_success() -> void:
 - `achievements_reset_success` SimpleSignal
 - `achievements_reset_fail` SignalWithArguments<Int,String>
 ### Leaderboards
-- `leaderboard_score_success` SimpleSignal
-- `leaderboard_score_fail` SignalWithArguments<Int,String>
+- `leaderboard_score_success` SignalWithArguments<String> - includes leaderboard ID
+- `leaderboard_score_fail` SignalWithArguments<Int,String,String> - includes leaderboard ID
 - `leaderboard_success` SimpleSignal
 - `leaderboard_dismissed` SimpleSignal
 - `leaderboard_fail` SignalWithArguments<Int,String>
+- `leaderboard_entries_load_success` SignalWithArguments<[GameCenterLeaderboardEntry],Int,String> - entries, total player count, leaderboard ID
+- `leaderboard_entries_load_fail` SignalWithArguments<Int,String,String> - includes leaderboard ID
+- `leaderboard_player_score_load_success` SignalWithArguments<GameCenterLeaderboardEntry,String> - player's entry, leaderboard ID
+- `leaderboard_player_score_load_fail` SignalWithArguments<Int,String,String> - includes leaderboard ID
+
+## Classes
+### GameCenterLeaderboardEntry
+Represents a leaderboard entry with the following properties:
+- `player: GameCenterPlayer` - The player who earned this score
+- `score: Int` - The score value
+- `rank: Int` - The player's rank (1 = first place)
+- `context: Int` - Developer-supplied context value
+
 ## Methods
 
 ### Authorization
@@ -86,6 +106,17 @@ func _on_leaderboard_success() -> void:
 - `showAchievements()` - Open GameCenter Achievements.
 - `showAchievement()` - Open GameCenter Achievements.
 ### Leaderboards
-- `submitScore()` - Update the progress of achievements.
+- `submitScore(score: Int, leaderboardIDs: [String], context: Int)` - Submit a score to one or more leaderboards.
 - `showLeaderboards()` - Open GameCenter Leaderboards.
-- `showLeaderboard()` - Open GameCenter Leaderboard.
+- `showLeaderboard(leaderboardID: String)` - Open a specific GameCenter Leaderboard.
+- `loadLeaderboardEntries(leaderboardID: String, playerScope: String, timeScope: String, rankMin: Int, rankMax: Int)` - Load leaderboard entries for a range of ranks. playerScope: "global" or "friendsOnly". timeScope: "allTime", "week", or "today".
+- `loadPlayerScore(leaderboardID: String, timeScope: String)` - Load the local player's score and rank. timeScope: "allTime", "week", or "today".
+
+# Breaking Changes
+
+## Leaderboard Signal Signatures (v1.1.0)
+The following signals now include the leaderboard ID to support async identification:
+- `leaderboard_score_success` - Changed from SimpleSignal to SignalWithArguments<String>
+- `leaderboard_score_fail` - Added leaderboard ID as third parameter
+
+Update your callback signatures accordingly when upgrading.

--- a/GameCenter/Swift/Sources/GameCenter/GameCenter+Leaderboards.swift
+++ b/GameCenter/Swift/Sources/GameCenter/GameCenter+Leaderboards.swift
@@ -17,7 +17,8 @@ extension GameCenter {
         guard GKLocalPlayer.local.isAuthenticated == true else {
             self.leaderboardScoreFail.emit(
                 GameCenterError.notAuthenticated.rawValue,
-                "Player is not authenticated")
+                "Player is not authenticated",
+                leaderboardIDs.joined(separator: ","))
             return
         }
         
@@ -28,10 +29,11 @@ extension GameCenter {
                 guard error == nil else {
                     self.leaderboardScoreFail.emit(
                         (error! as NSError).code,
-                        "Error while resetting achievements")
+                        "Error while submitting score",
+                        leaderboardIDs.joined(separator: ","))
                     return
                 }
-                self.leaderboardScoreSuccess.emit()
+                self.leaderboardScoreSuccess.emit(leaderboardIDs.joined(separator: ","))
             })
     }
 
@@ -75,5 +77,137 @@ extension GameCenter {
                 GameCenterError.notAvailable.rawValue,
                 "Leaderboard not available")
         #endif
+    }
+
+    func loadLeaderboardEntriesInternal(
+        leaderboardID: String,
+        playerScope: String,
+        timeScope: String,
+        rankMin: Int,
+        rankMax: Int
+    ) {
+        guard GKLocalPlayer.local.isAuthenticated == true else {
+            self.leaderboardEntriesLoadFail.emit(
+                GameCenterError.notAuthenticated.rawValue,
+                "Player is not authenticated",
+                leaderboardID)
+            return
+        }
+        
+        // Convert string parameters to enums
+        let gkPlayerScope: GKLeaderboard.PlayerScope = (playerScope == "friendsOnly") ? .friendsOnly : .global
+        let gkTimeScope: GKLeaderboard.TimeScope
+        switch timeScope {
+        case "today":
+            gkTimeScope = .today
+        case "week":
+            gkTimeScope = .week
+        default:
+            gkTimeScope = .allTime
+        }
+        
+        // Load the leaderboard
+        GKLeaderboard.loadLeaderboards(IDs: [leaderboardID]) { leaderboards, error in
+            guard error == nil, let leaderboard = leaderboards?.first else {
+                self.leaderboardEntriesLoadFail.emit(
+                    (error as NSError?)?.code ?? GameCenterError.unknownError.rawValue,
+                    error?.localizedDescription ?? "Failed to load leaderboard",
+                    leaderboardID
+                )
+                return
+            }
+            
+            // Load entries for the specified range
+            let range = NSRange(location: rankMin, length: rankMax - rankMin + 1)
+            leaderboard.loadEntries(
+                for: gkPlayerScope,
+                timeScope: gkTimeScope,
+                range: range
+            ) { localPlayerEntry, entries, totalPlayerCount, error in
+                guard error == nil else {
+                    self.leaderboardEntriesLoadFail.emit(
+                        (error! as NSError).code,
+                        "Error loading leaderboard entries",
+                        leaderboardID
+                    )
+                    return
+                }
+                
+                // Convert entries to Godot objects
+                var leaderboardEntries = ObjectCollection<GameCenterLeaderboardEntry>()
+                if let entries = entries {
+                    for entry in entries {
+                        leaderboardEntries.append(GameCenterLeaderboardEntry(entry))
+                    }
+                }
+                
+                self.leaderboardEntriesLoadSuccess.emit(leaderboardEntries, totalPlayerCount, leaderboardID)
+            }
+        }
+    }
+
+    func loadPlayerScoreInternal(
+        leaderboardID: String,
+        timeScope: String
+    ) {
+        guard GKLocalPlayer.local.isAuthenticated == true else {
+            self.leaderboardPlayerScoreLoadFail.emit(
+                GameCenterError.notAuthenticated.rawValue,
+                "Player is not authenticated",
+                leaderboardID)
+            return
+        }
+        
+        // Convert string parameter to enum
+        let gkTimeScope: GKLeaderboard.TimeScope
+        switch timeScope {
+        case "today":
+            gkTimeScope = .today
+        case "week":
+            gkTimeScope = .week
+        default:
+            gkTimeScope = .allTime
+        }
+        
+        // Load the leaderboard
+        GKLeaderboard.loadLeaderboards(IDs: [leaderboardID]) { leaderboards, error in
+            guard error == nil, let leaderboard = leaderboards?.first else {
+                self.leaderboardPlayerScoreLoadFail.emit(
+                    (error as NSError?)?.code ?? GameCenterError.unknownError.rawValue,
+                    error?.localizedDescription ?? "Failed to load leaderboard",
+                    leaderboardID
+                )
+                return
+            }
+            
+            // Load just the player's entry
+            leaderboard.loadEntries(
+                for: .global,
+                timeScope: gkTimeScope,
+                range: NSRange(location: 1, length: 1)
+            ) { localPlayerEntry, entries, totalPlayerCount, error in
+                guard error == nil else {
+                    self.leaderboardPlayerScoreLoadFail.emit(
+                        (error! as NSError).code,
+                        "Error loading player score",
+                        leaderboardID
+                    )
+                    return
+                }
+                
+                guard let localPlayerEntry = localPlayerEntry else {
+                    self.leaderboardPlayerScoreLoadFail.emit(
+                        GameCenterError.unknownError.rawValue,
+                        "No score found for player",
+                        leaderboardID
+                    )
+                    return
+                }
+                
+                // Convert to Godot object and emit
+                let playerEntry = GameCenterLeaderboardEntry(localPlayerEntry)
+                self.leaderboardPlayerScoreLoadSuccess.emit(playerEntry, leaderboardID)
+            }
+        }
     }
 }

--- a/GameCenter/Swift/Sources/GameCenter/GameCenter.swift
+++ b/GameCenter/Swift/Sources/GameCenter/GameCenter.swift
@@ -74,6 +74,12 @@ class GameCenter: Object {
 
     // MARK: Leaderboards
     /// @Signal
+    /// Score(s) have been successfully reported
+    @Signal var leaderboardScoreSuccess: SimpleSignal
+    /// @Signal
+    /// Error reporting the score
+    @Signal var leaderboardScoreFail: SignalWithArguments<Int, String>
+    /// @Signal
     /// Leaderboard has been shown
     @Signal var leaderboardSuccess: SimpleSignal
     /// @Signal
@@ -83,11 +89,11 @@ class GameCenter: Object {
     /// Error showing the leaderboard
     @Signal var leaderboardFail: SignalWithArguments<Int, String>
     /// @Signal
-    /// Score(s) have been successfully reported - includes leaderboard ID
-    @Signal var leaderboardScoreSuccess: SignalWithArguments<String>
+    /// Score(s) have been successfully reported - includes leaderboard ID for in-game tracking
+    @Signal var leaderboardScoreIngameSuccess: SignalWithArguments<String>
     /// @Signal
-    /// Error reporting the score - includes leaderboard ID
-    @Signal var leaderboardScoreFail: SignalWithArguments<Int, String, String>
+    /// Error reporting the score - includes leaderboard ID for in-game tracking
+    @Signal var leaderboardScoreIngameFail: SignalWithArguments<Int, String, String>
     /// @Signal
     /// Leaderboard entries have been successfully loaded - includes leaderboard ID
     @Signal var leaderboardEntriesLoadSuccess: SignalWithArguments<ObjectCollection<GameCenterLeaderboardEntry>, Int, String>

--- a/GameCenter/Swift/Sources/GameCenter/GameCenter.swift
+++ b/GameCenter/Swift/Sources/GameCenter/GameCenter.swift
@@ -20,6 +20,7 @@ import SwiftGodot
         GameCenterAchievementDescription.self,
         GameCenterPlayer.self,
         GameCenterPlayerLocal.self,
+        GameCenterLeaderboardEntry.self,
     ]
 )
 
@@ -70,12 +71,8 @@ class GameCenter: Object {
     /// @Signal
     /// Error reporting the achievements
     @Signal var achievementsDescriptionFail: SignalWithArguments<Int, String>
-    /// @Signal
-    /// Score(s) have been successfully reported
-    @Signal var leaderboardScoreSuccess: SimpleSignal
-    /// @Signal
-    /// Error reporting the score
-    @Signal var leaderboardScoreFail: SignalWithArguments<Int, String>
+
+    // MARK: Leaderboards
     /// @Signal
     /// Leaderboard has been shown
     @Signal var leaderboardSuccess: SimpleSignal
@@ -85,7 +82,26 @@ class GameCenter: Object {
     /// @Signal
     /// Error showing the leaderboard
     @Signal var leaderboardFail: SignalWithArguments<Int, String>
-
+    /// @Signal
+    /// Score(s) have been successfully reported - includes leaderboard ID
+    @Signal var leaderboardScoreSuccess: SignalWithArguments<String>
+    /// @Signal
+    /// Error reporting the score - includes leaderboard ID
+    @Signal var leaderboardScoreFail: SignalWithArguments<Int, String, String>
+    /// @Signal
+    /// Leaderboard entries have been successfully loaded - includes leaderboard ID
+    @Signal var leaderboardEntriesLoadSuccess: SignalWithArguments<ObjectCollection<GameCenterLeaderboardEntry>, Int, String>
+    /// @Signal
+    /// Error loading leaderboard entries - includes leaderboard ID
+    @Signal var leaderboardEntriesLoadFail: SignalWithArguments<Int, String, String>
+    /// @Signal
+    /// Player's score and rank have been successfully loaded - includes leaderboard ID
+    @Signal var leaderboardPlayerScoreLoadSuccess: SignalWithArguments<GameCenterLeaderboardEntry, String>
+    /// @Signal
+    /// Error loading player's score - includes leaderboard ID
+    @Signal var leaderboardPlayerScoreLoadFail: SignalWithArguments<Int, String, String>
+    
+    
     #if canImport(UIKit)
         var viewController: GameCenterViewController =
             GameCenterViewController()
@@ -252,4 +268,56 @@ class GameCenter: Object {
     func showLeaderboard(leaderboardID: String) {
         showLeaderboardInternal(leaderboardID: leaderboardID)
     }
-}
+    
+    /// @Callable
+    ///
+    /// Load entries from a leaderboard
+    ///
+    /// - Parameters:
+    ///     - leaderboardID: The identifier for the leaderboard
+    ///     - playerScope: "global" or "friendsOnly"
+    ///     - timeScope: "allTime", "week", or "today"
+    ///     - rankMin: Starting rank to load (1 = first place)
+    ///     - rankMax: Ending rank to load
+    ///
+    /// - Signals:
+    ///     - leaderboard_entries_load_success: entries and total player count
+    ///     - leaderboard_entries_load_fail: error message
+    @Callable
+    func loadLeaderboardEntries(
+        leaderboardID: String,
+        playerScope: String,
+        timeScope: String,
+        rankMin: Int,
+        rankMax: Int
+    ) {
+        loadLeaderboardEntriesInternal(
+            leaderboardID: leaderboardID,
+            playerScope: playerScope,
+            timeScope: timeScope,
+            rankMin: rankMin,
+            rankMax: rankMax
+        )
+    }
+
+    /// @Callable
+    ///
+    /// Load the local player's score and rank for a leaderboard
+    ///
+    /// - Parameters:
+    ///     - leaderboardID: The identifier for the leaderboard
+    ///     - timeScope: "allTime", "week", or "today"
+    ///
+    /// - Signals:
+    ///     - leaderboard_player_score_load_success: player's entry
+    ///     - leaderboard_player_score_load_fail: error message
+    @Callable
+    func loadPlayerScore(
+        leaderboardID: String,
+        timeScope: String
+    ) {
+        loadPlayerScoreInternal(
+            leaderboardID: leaderboardID,
+            timeScope: timeScope
+        )
+    }}

--- a/GameCenter/Swift/Sources/GameCenter/GameCenterLeaderboardEntry.swift
+++ b/GameCenter/Swift/Sources/GameCenter/GameCenterLeaderboardEntry.swift
@@ -1,0 +1,46 @@
+//
+//  GameCenterLeaderboardEntry.swift
+//  GameCenter
+//
+//  Created by Michael Morris on 11/23/25.
+//
+
+import GameKit
+import SwiftGodot
+
+@Godot
+class GameCenterLeaderboardEntry: Object {
+    // MARK: Export
+    /// @Export
+    /// The player who earned this score
+    @Export var player: GameCenterPlayer?
+    /// @Export
+    /// The score value
+    @Export var score: Int = 0
+    /// @Export
+    /// The player's rank (1 = first place)
+    @Export var rank: Int = 0
+    /// @Export
+    /// Developer-supplied context value
+    @Export var context: Int = 0
+    
+    // NOTE: The date field is commented out because accessing entry.date
+    // causes a crash when bridging from Objective-C on some iOS versions.
+    // Error: "Date._unconditionallyBridgeFromObjectiveC" in crash logs.
+    // Since we don't currently use the date field, it's disabled.
+    // To re-enable, uncomment the field and add safe unwrapping in init.
+    //
+    // /// @Export
+    // /// Date the score was earned
+    // @Export var date: Double = 0
+    
+    convenience init(_ entry: GKLeaderboard.Entry) {
+        self.init()
+        self.player = GameCenterPlayer(entry.player)
+        self.score = entry.score
+        self.rank = entry.rank
+        self.context = entry.context
+        // See NOTE above - date access disabled due to crash
+        // self.date = entry.date.timeIntervalSince1970
+    }
+}


### PR DESCRIPTION
Description:
This PR adds the ability to retrieve leaderboard data programmatically, which was missing from the original implementation.
New Features

loadPlayerScore(leaderboardID, timeScope) - Get local player's rank and score
loadLeaderboardEntries(leaderboardID, playerScope, timeScope, rankMin, rankMax) - Get top scores
GameCenterLeaderboardEntry class - Data object for leaderboard entries

Breaking Changes

leaderboard_score_success changed from SimpleSignal to SignalWithArguments<String> (returns leaderboard ID)
leaderboard_score_fail now includes leaderboard ID as third parameter

Why
The original plugin only supported submitting scores and showing the GameCenter UI. There was no way to retrieve the player's rank or display leaderboard data in-game.
Tested

iOS 18.6.2
iPhone 16 Pro Max
Godot 4.5