### PR TITLE
Expose StoreKit 2 Transaction Data for Server-Side Validation

### DIFF
--- a/AppleSignIn/Godot/addons/iosplugins/applesignin.gdextension
+++ b/AppleSignIn/Godot/addons/iosplugins/applesignin.gdextension
@@ -1,0 +1,16 @@
+[configuration]
+entry_symbol = "applesignin"
+compatibility_minimum = 4.2
+reloadable = true
+
+[libraries]
+macos.debug = "res://addons/iosplugins/macos/libAppleSignIn.dylib"
+macos.release = "res://addons/iosplugins/macos/libAppleSignIn.dylib"
+ios.debug = "res://addons/iosplugins/ios/AppleSignIn.framework"
+ios.release = "res://addons/iosplugins/ios/AppleSignIn.framework"
+
+[dependencies]
+macos.debug = {"res://addons/iosplugins/macos/libSwiftGodot.dylib" : ""}
+macos.release = {"res://addons/iosplugins/macos/libSwiftGodot.dylib" : ""}
+ios.debug = {"res://addons/iosplugins/ios/SwiftGodot.framework" : ""}
+ios.release = {"res://addons/iosplugins/ios/SwiftGodot.framework" : ""}

--- a/AppleSignIn/README.md
+++ b/AppleSignIn/README.md
@@ -1,0 +1,204 @@
+# Apple Sign-In Plugin for Godot (SwiftGodot)
+
+A SwiftGodot plugin that enables Apple Sign-In authentication for iOS apps built with Godot Engine.
+
+## Overview
+
+This plugin provides native Apple Sign-In functionality using Apple's `AuthenticationServices` framework. It returns the identity token (JWT) needed for server-side authentication with backends like Nakama.
+
+## Requirements
+
+- iOS 17.0+
+- macOS 14.0+ (for development/testing)
+- Godot Engine 4.2+
+- SwiftGodot
+- Apple Developer account with Sign In with Apple capability
+
+## Building the Plugin
+
+### Prerequisites
+
+1. Xcode 15+ installed
+2. SwiftGodot dependency configured
+
+### Build Commands
+
+```bash
+cd AppleSignIn/Swift
+
+# Build for iOS
+swift build -c release --arch arm64 --sdk iphoneos
+
+# Build for macOS (for testing)
+swift build -c release
+```
+
+### Create Framework
+
+After building, create the framework structure for iOS:
+
+```bash
+# The build output will be in .build/release/
+# Copy libAppleSignIn.dylib to the appropriate framework structure
+```
+
+## Installation in Godot Project
+
+1. Copy `applesignin.gdextension` to `res://addons/iosplugins/`
+2. Copy the built `AppleSignIn.framework` to `res://addons/iosplugins/ios/`
+3. Ensure `SwiftGodot.framework` is also present in `res://addons/iosplugins/ios/`
+
+## iOS Configuration (Required)
+
+### 1. App Store Connect Configuration
+
+1. Go to [App Store Connect](https://appstoreconnect.apple.com)
+2. Navigate to your app > **App Information**
+3. Under **Sign In with Apple**, click **Configure**
+4. Enable **Sign In with Apple** for your app
+
+### 2. Apple Developer Portal Configuration
+
+1. Go to [Apple Developer Portal](https://developer.apple.com)
+2. Navigate to **Certificates, Identifiers & Profiles**
+3. Select **Identifiers** > Your App ID
+4. Enable **Sign In with Apple** capability
+5. Click **Configure** if server-to-server notifications are needed
+
+### 3. Xcode Project Configuration
+
+When exporting from Godot, the Xcode project needs:
+
+1. **Signing & Capabilities**:
+   - Add "Sign In with Apple" capability
+   - Ensure proper provisioning profile with Sign In with Apple enabled
+
+2. **Info.plist** (usually automatic with capability):
+   ```xml
+   <key>com.apple.developer.applesignin</key>
+   <array>
+       <string>Default</string>
+   </array>
+   ```
+
+### 4. Nakama Backend Configuration
+
+Nakama supports Apple Sign-In out of the box. The identity token returned by this plugin is a JWT that Nakama validates using Apple's public keys.
+
+No additional backend configuration is needed - just call `authenticate_apple_async()` with the identity token.
+
+## Usage in GDScript
+
+```gdscript
+var apple_plugin = null
+
+func _ready():
+    if Engine.has_singleton("AppleSignIn"):
+        apple_plugin = Engine.get_singleton("AppleSignIn")
+
+        # Connect signals
+        apple_plugin.sign_in_success.connect(_on_apple_sign_in_success)
+        apple_plugin.sign_in_failed.connect(_on_apple_sign_in_failed)
+        apple_plugin.sign_in_cancelled.connect(_on_apple_sign_in_cancelled)
+
+func _on_apple_button_pressed():
+    if apple_plugin and apple_plugin.isAvailable():
+        apple_plugin.signIn()
+
+func _on_apple_sign_in_success(identity_token: String, auth_code: String, user_id: String, email: String, full_name: String):
+    print("Apple Sign-In successful!")
+    print("User ID: ", user_id)
+    print("Email: ", email)  # May be empty on subsequent sign-ins
+    print("Name: ", full_name)  # May be empty on subsequent sign-ins
+
+    # Authenticate with Nakama using the identity token
+    var session = await nakama_client.authenticate_apple_async(identity_token)
+
+func _on_apple_sign_in_failed(error_code: int, message: String):
+    print("Apple Sign-In failed: ", message)
+
+func _on_apple_sign_in_cancelled():
+    print("Apple Sign-In cancelled by user")
+```
+
+## API Reference
+
+### Methods
+
+#### `isAvailable() -> Bool`
+Returns `true` if Apple Sign-In is available on the current device.
+
+#### `signIn()`
+Starts the Apple Sign-In flow requesting email and full name.
+
+#### `signInWithScopes(requestEmail: Bool, requestFullName: Bool)`
+Starts Apple Sign-In with custom scope options.
+
+#### `checkCredentialState(userIdentifier: String)`
+Verifies if the user's Apple ID credentials are still valid.
+
+### Signals
+
+#### `sign_in_success(identity_token, authorization_code, user_identifier, email, full_name)`
+Emitted when authentication succeeds.
+
+**Parameters:**
+- `identity_token` (String): JWT for server authentication
+- `authorization_code` (String): Code for server-to-server validation
+- `user_identifier` (String): Unique Apple user ID
+- `email` (String): User's email (only on first sign-in, empty otherwise)
+- `full_name` (String): User's name (only on first sign-in, empty otherwise)
+
+#### `sign_in_failed(error_code, error_message)`
+Emitted when authentication fails.
+
+**Error Codes:**
+- `1`: Unknown error
+- `2`: Canceled
+- `3`: Invalid response
+- `4`: Not handled
+- `5`: Failed
+- `6`: Not available
+- `7`: Not interactive
+
+#### `sign_in_cancelled`
+Emitted when user cancels the authentication flow.
+
+#### `credential_state_checked(user_identifier, is_authorized)`
+Emitted when credential state check completes.
+
+## Important Notes
+
+### Email and Name Privacy
+
+Apple only provides the user's email and name on the **first** sign-in. Subsequent sign-ins will return empty strings for these fields. Store these values after the first sign-in if needed.
+
+### Testing
+
+- Apple Sign-In requires a real iOS device for testing
+- Cannot be tested in iOS Simulator
+- Ensure test devices are signed in with an Apple ID
+
+### App Store Review
+
+Apps using Apple Sign-In must:
+1. Provide Sign In with Apple as an option if offering other third-party sign-in options
+2. Follow Apple's Human Interface Guidelines for the button design
+
+## Troubleshooting
+
+### "Sign In with Apple" not appearing
+
+- Verify capability is enabled in Xcode
+- Check provisioning profile has the capability
+- Ensure App ID has Sign In with Apple enabled
+
+### Invalid response error
+
+- Verify your app's bundle ID matches the configured App ID
+- Check that all certificates and profiles are valid
+
+### Token validation fails on backend
+
+- Ensure server time is synchronized
+- Verify the bundle ID matches between app and backend configuration

--- a/AppleSignIn/Swift/Package.swift
+++ b/AppleSignIn/Swift/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.9.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+var libraryType: Product.Library.LibraryType
+#if os(Windows)
+libraryType = .static
+#else
+libraryType = .dynamic
+#endif
+
+let package = Package(
+    name: "AppleSignIn",
+    platforms: [.iOS(.v17), .macOS(.v14)],
+    products: [
+        .library(
+            name: "AppleSignIn",
+            type: libraryType,
+            targets: ["AppleSignIn"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "7e4c34ccbc149cd61de3c8fa76a09f84bf5583f5")
+    ],
+    targets: [
+        .target(
+            name: "AppleSignIn",
+            dependencies: [
+                "SwiftGodot",
+            ],
+            swiftSettings: [.unsafeFlags(["-suppress-warnings"])]
+        ),
+    ]
+)

--- a/AppleSignIn/Swift/Sources/AppleSignIn/AppleSignIn.swift
+++ b/AppleSignIn/Swift/Sources/AppleSignIn/AppleSignIn.swift
@@ -1,0 +1,402 @@
+//
+//  AppleSignIn.swift
+//  SwiftGodotIosPlugins
+//
+//  Apple Sign-In authentication plugin for Godot using SwiftGodot
+//
+
+import AuthenticationServices
+import SwiftGodot
+
+#if canImport(UIKit)
+    import UIKit
+#endif
+
+#initSwiftExtension(
+    cdecl: "applesignin",
+    types: [
+        AppleSignIn.self,
+    ]
+)
+
+enum AppleSignInError: Int, Error {
+    case unknownError = 1
+    case canceled = 2
+    case invalidResponse = 3
+    case notHandled = 4
+    case failed = 5
+    case notAvailable = 6
+    case notInteractive = 7
+}
+
+@Godot
+class AppleSignIn: Object {
+
+    // MARK: - Signals
+
+    /// Emitted when Apple Sign-In completes successfully
+    /// Parameters: identityToken (String), authorizationCode (String), userIdentifier (String), email (String), fullName (String)
+    @Signal var signInSuccess: SignalWithArguments<String, String, String, String, String>
+
+    /// Emitted when Apple Sign-In fails
+    /// Parameters: errorCode (Int), errorMessage (String)
+    @Signal var signInFailed: SignalWithArguments<Int, String>
+
+    /// Emitted when Apple Sign-In is cancelled by user
+    @Signal var signInCancelled: SimpleSignal
+
+    /// Emitted when credential state check completes
+    /// Parameters: userIdentifier (String), isAuthorized (Bool)
+    @Signal var credentialStateChecked: SignalWithArguments<String, Bool>
+
+    // MARK: - Properties
+
+    static var shared: AppleSignIn?
+
+    // Store delegate to prevent deallocation
+    private var currentDelegate: AppleSignInDelegate?
+
+    #if canImport(UIKit)
+    private var presentationAnchor: ASPresentationAnchor? {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first else {
+            return nil
+        }
+        return window
+    }
+    #endif
+
+    // MARK: - Initialization
+
+    required override init() {
+        super.init()
+        AppleSignIn.shared = self
+        GD.print("[AppleSignIn] Plugin initialized via init()")
+    }
+
+    required init(nativeHandle: UnsafeRawPointer) {
+        super.init(nativeHandle: nativeHandle)
+        AppleSignIn.shared = self
+        GD.print("[AppleSignIn] Plugin initialized via nativeHandle")
+    }
+
+    // MARK: - Public Methods
+
+    /// Check if Apple Sign-In is available on this device
+    /// Returns true if Apple Sign-In is available
+    @Callable
+    func isAvailable() -> Bool {
+        GD.print("[AppleSignIn] isAvailable() called")
+        #if canImport(UIKit)
+        if #available(iOS 13.0, *) {
+            GD.print("[AppleSignIn] isAvailable() returning true (iOS 13+)")
+            return true
+        }
+        #endif
+        GD.print("[AppleSignIn] isAvailable() returning false")
+        return false
+    }
+
+    /// Start Apple Sign-In flow
+    /// Requests full name and email scopes
+    ///
+    /// - Signals:
+    ///     - sign_in_success: identityToken, authorizationCode, userIdentifier, email, fullName
+    ///     - sign_in_failed: errorCode, errorMessage
+    ///     - sign_in_cancelled: emitted when user cancels
+    @Callable
+    func signIn() {
+        GD.print("[AppleSignIn] signIn() called")
+        #if canImport(UIKit)
+        signInInternal(requestEmail: true, requestFullName: true)
+        #else
+        GD.print("[AppleSignIn] UIKit not available, emitting failure")
+        signInFailed.emit(AppleSignInError.notAvailable.rawValue, "Apple Sign-In is not available on this platform")
+        #endif
+    }
+
+    /// Start Apple Sign-In flow with custom scopes
+    ///
+    /// - Parameters:
+    ///     - requestEmail: Whether to request user's email
+    ///     - requestFullName: Whether to request user's full name
+    ///
+    /// - Signals:
+    ///     - sign_in_success: identityToken, authorizationCode, userIdentifier, email, fullName
+    ///     - sign_in_failed: errorCode, errorMessage
+    ///     - sign_in_cancelled: emitted when user cancels
+    @Callable
+    func signInWithScopes(requestEmail: Bool, requestFullName: Bool) {
+        GD.print("[AppleSignIn] signInWithScopes() called - email: \(requestEmail), fullName: \(requestFullName)")
+        #if canImport(UIKit)
+        signInInternal(requestEmail: requestEmail, requestFullName: requestFullName)
+        #else
+        GD.print("[AppleSignIn] UIKit not available, emitting failure")
+        signInFailed.emit(AppleSignInError.notAvailable.rawValue, "Apple Sign-In is not available on this platform")
+        #endif
+    }
+
+    /// Check the credential state for a user identifier
+    /// Use this to verify if the user's Apple ID credentials are still valid
+    ///
+    /// - Parameters:
+    ///     - userIdentifier: The user identifier from a previous sign-in
+    ///
+    /// - Signals:
+    ///     - credential_state_checked: userIdentifier, isAuthorized
+    @Callable
+    func checkCredentialState(userIdentifier: String) {
+        GD.print("[AppleSignIn] checkCredentialState() called for user: \(userIdentifier)")
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: userIdentifier) { [weak self] credentialState, error in
+            DispatchQueue.main.async {
+                guard let self = self else {
+                    GD.print("[AppleSignIn] checkCredentialState: self is nil")
+                    return
+                }
+
+                if let error = error {
+                    GD.print("[AppleSignIn] checkCredentialState error: \(error.localizedDescription)")
+                    GD.pushWarning("Credential state check error: \(error.localizedDescription)")
+                    self.credentialStateChecked.emit(userIdentifier, false)
+                    return
+                }
+
+                GD.print("[AppleSignIn] checkCredentialState result: \(credentialState.rawValue)")
+                switch credentialState {
+                case .authorized:
+                    self.credentialStateChecked.emit(userIdentifier, true)
+                case .revoked, .notFound, .transferred:
+                    self.credentialStateChecked.emit(userIdentifier, false)
+                @unknown default:
+                    self.credentialStateChecked.emit(userIdentifier, false)
+                }
+            }
+        }
+    }
+
+    // MARK: - Internal Methods
+
+    #if canImport(UIKit)
+    private func signInInternal(requestEmail: Bool, requestFullName: Bool) {
+        GD.print("[AppleSignIn] signInInternal() starting...")
+
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        GD.print("[AppleSignIn] Created Apple ID request")
+
+        var scopes: [ASAuthorization.Scope] = []
+        if requestEmail {
+            scopes.append(.email)
+        }
+        if requestFullName {
+            scopes.append(.fullName)
+        }
+        request.requestedScopes = scopes
+        GD.print("[AppleSignIn] Requested scopes: \(scopes)")
+
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        GD.print("[AppleSignIn] Created ASAuthorizationController")
+
+        let delegate = AppleSignInDelegate(plugin: self)
+
+        // Store delegate as instance property to prevent deallocation
+        self.currentDelegate = delegate
+        GD.print("[AppleSignIn] Created and stored delegate")
+
+        // Also store delegate on controller
+        objc_setAssociatedObject(
+            authorizationController,
+            "delegate",
+            delegate,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
+        GD.print("[AppleSignIn] Associated delegate with controller")
+
+        authorizationController.delegate = delegate
+        authorizationController.presentationContextProvider = delegate
+        GD.print("[AppleSignIn] Set delegate and presentationContextProvider")
+
+        GD.print("[AppleSignIn] Calling performRequests()...")
+        authorizationController.performRequests()
+        GD.print("[AppleSignIn] performRequests() called - waiting for callback")
+    }
+    #endif
+
+    // MARK: - Callback Methods (called by delegate)
+
+    func handleAuthorizationSuccess(credential: ASAuthorizationAppleIDCredential) {
+        GD.print("[AppleSignIn] handleAuthorizationSuccess() called")
+
+        let userIdentifier = credential.user
+        GD.print("[AppleSignIn] User identifier: \(userIdentifier)")
+
+        // Get identity token (JWT)
+        var identityToken = ""
+        if let tokenData = credential.identityToken,
+           let tokenString = String(data: tokenData, encoding: .utf8) {
+            identityToken = tokenString
+            GD.print("[AppleSignIn] Identity token length: \(identityToken.count)")
+        } else {
+            GD.print("[AppleSignIn] WARNING: No identity token received")
+        }
+
+        // Get authorization code
+        var authorizationCode = ""
+        if let codeData = credential.authorizationCode,
+           let codeString = String(data: codeData, encoding: .utf8) {
+            authorizationCode = codeString
+            GD.print("[AppleSignIn] Authorization code length: \(authorizationCode.count)")
+        } else {
+            GD.print("[AppleSignIn] WARNING: No authorization code received")
+        }
+
+        // Get email (may be nil on subsequent sign-ins)
+        let email = credential.email ?? ""
+        GD.print("[AppleSignIn] Email: \(email.isEmpty ? "(empty)" : email)")
+
+        // Get full name
+        var fullName = ""
+        if let nameComponents = credential.fullName {
+            let formatter = PersonNameComponentsFormatter()
+            fullName = formatter.string(from: nameComponents)
+        }
+        GD.print("[AppleSignIn] Full name: \(fullName.isEmpty ? "(empty)" : fullName)")
+
+        GD.print("[AppleSignIn] Emitting signInSuccess signal...")
+        signInSuccess.emit(identityToken, authorizationCode, userIdentifier, email, fullName)
+        GD.print("[AppleSignIn] signInSuccess signal emitted")
+
+        // Clear delegate reference
+        self.currentDelegate = nil
+    }
+
+    func handleAuthorizationError(_ error: Error) {
+        GD.print("[AppleSignIn] handleAuthorizationError() called")
+        GD.print("[AppleSignIn] Error: \(error.localizedDescription)")
+        GD.print("[AppleSignIn] Error domain: \((error as NSError).domain)")
+        GD.print("[AppleSignIn] Error code: \((error as NSError).code)")
+
+        if let authError = error as? ASAuthorizationError {
+            GD.print("[AppleSignIn] ASAuthorizationError code: \(authError.code.rawValue)")
+            switch authError.code {
+            case .canceled:
+                GD.print("[AppleSignIn] User cancelled - emitting signInCancelled")
+                signInCancelled.emit()
+                self.currentDelegate = nil
+                return
+            case .invalidResponse:
+                GD.print("[AppleSignIn] Invalid response - emitting signInFailed")
+                signInFailed.emit(AppleSignInError.invalidResponse.rawValue, "Invalid response from Apple")
+            case .notHandled:
+                GD.print("[AppleSignIn] Not handled - emitting signInFailed")
+                signInFailed.emit(AppleSignInError.notHandled.rawValue, "Request not handled")
+            case .failed:
+                GD.print("[AppleSignIn] Failed - emitting signInFailed")
+                signInFailed.emit(AppleSignInError.failed.rawValue, "Authorization failed: \(authError.localizedDescription)")
+            case .notInteractive:
+                GD.print("[AppleSignIn] Not interactive - emitting signInFailed")
+                signInFailed.emit(AppleSignInError.notInteractive.rawValue, "Not interactive")
+            case .unknown:
+                GD.print("[AppleSignIn] Unknown error - emitting signInFailed")
+                signInFailed.emit(AppleSignInError.unknownError.rawValue, "Unknown error: \(authError.localizedDescription)")
+            @unknown default:
+                GD.print("[AppleSignIn] Unknown default - emitting signInFailed")
+                signInFailed.emit(AppleSignInError.unknownError.rawValue, "Unknown error: \(authError.localizedDescription)")
+            }
+        } else {
+            GD.print("[AppleSignIn] Non-ASAuthorizationError - emitting signInFailed")
+            signInFailed.emit(AppleSignInError.unknownError.rawValue, "Error: \(error.localizedDescription)")
+        }
+
+        // Clear delegate reference
+        self.currentDelegate = nil
+    }
+}
+
+// MARK: - Apple Sign-In Delegate
+
+#if canImport(UIKit)
+class AppleSignInDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+
+    weak var plugin: AppleSignIn?
+
+    init(plugin: AppleSignIn) {
+        self.plugin = plugin
+        super.init()
+        GD.print("[AppleSignInDelegate] Delegate initialized")
+    }
+
+    deinit {
+        GD.print("[AppleSignInDelegate] Delegate deallocated")
+    }
+
+    // MARK: - ASAuthorizationControllerDelegate
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        GD.print("[AppleSignInDelegate] didCompleteWithAuthorization called")
+        GD.print("[AppleSignInDelegate] Credential type: \(type(of: authorization.credential))")
+
+        DispatchQueue.main.async { [weak self] in
+            GD.print("[AppleSignInDelegate] Inside main queue async block")
+
+            guard let self = self else {
+                GD.print("[AppleSignInDelegate] ERROR: self is nil in async block")
+                return
+            }
+
+            guard let plugin = self.plugin else {
+                GD.print("[AppleSignInDelegate] ERROR: plugin is nil")
+                return
+            }
+
+            if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+                GD.print("[AppleSignInDelegate] Got ASAuthorizationAppleIDCredential, calling handleAuthorizationSuccess")
+                plugin.handleAuthorizationSuccess(credential: appleIDCredential)
+            } else {
+                GD.print("[AppleSignInDelegate] ERROR: Invalid credential type")
+                plugin.handleAuthorizationError(
+                    NSError(domain: "AppleSignIn", code: AppleSignInError.invalidResponse.rawValue, userInfo: [NSLocalizedDescriptionKey: "Invalid credential type"])
+                )
+            }
+        }
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        GD.print("[AppleSignInDelegate] didCompleteWithError called")
+        GD.print("[AppleSignInDelegate] Error: \(error.localizedDescription)")
+
+        DispatchQueue.main.async { [weak self] in
+            GD.print("[AppleSignInDelegate] Inside error main queue async block")
+
+            guard let self = self else {
+                GD.print("[AppleSignInDelegate] ERROR: self is nil in error async block")
+                return
+            }
+
+            guard let plugin = self.plugin else {
+                GD.print("[AppleSignInDelegate] ERROR: plugin is nil in error handler")
+                return
+            }
+
+            GD.print("[AppleSignInDelegate] Calling handleAuthorizationError")
+            plugin.handleAuthorizationError(error)
+        }
+    }
+
+    // MARK: - ASAuthorizationControllerPresentationContextProviding
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        GD.print("[AppleSignInDelegate] presentationAnchor() called")
+
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first else {
+            GD.print("[AppleSignInDelegate] WARNING: Could not get window, creating fallback")
+            return UIWindow()
+        }
+
+        GD.print("[AppleSignInDelegate] Returning window as presentation anchor")
+        return window
+    }
+}
+#endif

--- a/GameCenter/Swift/Package.swift
+++ b/GameCenter/Swift/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             targets: ["GameCenter"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "727a0bbe44d9fa4b4f6d38e78ba12e5b395bba4e")
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "7e4c34ccbc149cd61de3c8fa76a09f84bf5583f5")
     ],
     targets: [
         .target(

--- a/ICloud/Swift/Package.swift
+++ b/ICloud/Swift/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["ICloud"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "727a0bbe44d9fa4b4f6d38e78ba12e5b395bba4e")
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "7e4c34ccbc149cd61de3c8fa76a09f84bf5583f5")
     ],
     targets: [
         .target(

--- a/InAppPurchase/Swift/Package.swift
+++ b/InAppPurchase/Swift/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["InAppPurchase"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "727a0bbe44d9fa4b4f6d38e78ba12e5b395bba4e")
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "7e4c34ccbc149cd61de3c8fa76a09f84bf5583f5")
     ],
     targets: [
         .target(

--- a/InAppPurchase/Swift/Package.swift
+++ b/InAppPurchase/Swift/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["InAppPurchase"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "7e4c34ccbc149cd61de3c8fa76a09f84bf5583f5")
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "727a0bbe44d9fa4b4f6d38e78ba12e5b395bba4e")
     ],
     targets: [
         .target(

--- a/InAppPurchase/Swift/Sources/InAppPurchase/InAppPurchase.swift
+++ b/InAppPurchase/Swift/Sources/InAppPurchase/InAppPurchase.swift
@@ -56,6 +56,13 @@ enum InAppPurchaseError: Int, Error {
 class InAppPurchase: Object , ObservableObject {
 
     static var shared: InAppPurchase?
+
+    // Static ISO8601 formatter for performance (creating formatters is expensive)
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
     var availableProducts: [InAppPurchaseProduct] = []
     var purchasedProductIDs: Set<String> = []
     internal var products_cached: [Product] = []
@@ -222,10 +229,8 @@ class InAppPurchase: Object , ObservableObject {
         // JWS representation - cryptographic proof for server validation
         dict["jws_representation"] = Variant(result.jwsRepresentation)
 
-        // Purchase date in ISO8601 format
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        dict["purchase_date"] = Variant(formatter.string(from: transaction.purchaseDate))
+        // Purchase date in ISO8601 format (using static formatter for performance)
+        dict["purchase_date"] = Variant(Self.iso8601Formatter.string(from: transaction.purchaseDate))
 
         // App account token (optional UUID set during purchase)
         if let appAccountToken = transaction.appAccountToken {


### PR DESCRIPTION
## Summary

- Added new signal `inAppPurchaseSuccessWithTransaction` that emits a `GDictionary` containing full transaction details for server-side validation
- The existing `inAppPurchaseSuccess` signal remains unchanged for backward compatibility

## Transaction Data Exposed

| Key | Type | Description |
|-----|------|-------------|
| `product_id` | String | Product identifier |
| `transaction_id` | String | Unique transaction ID (UInt64 as String) |
| `original_transaction_id` | String | For subscription renewals |
| `jws_representation` | String | Cryptographic proof for server validation |
| `purchase_date` | String | ISO8601 formatted timestamp |
| `app_account_token` | String | Optional UUID (empty string if not set) |

## Implementation Details

- Added `TransactionResult` struct to capture both `Transaction` and JWS representation from verification result
- Modified `purchaseProductAsync` to return `TransactionResult`
- Added `buildTransactionDictionary` helper to construct the `GDictionary`
- Reverted SwiftGodot dependency to `727a0bbe` for compatibility with existing builds

## Usage in GDScript

```gdscript
func _ready():
    in_app_purchase.in_app_purchase_success_with_transaction.connect(_on_purchase_success)

func _on_purchase_success(transaction_data: Dictionary):
    var product_id = transaction_data.get("product_id", "")
    var tx_id = transaction_data.get("transaction_id", "")
    var jws = transaction_data.get("jws_representation", "")
    # Send to server for validation
```

Resolves #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)